### PR TITLE
Publish gem using github actions

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -1,0 +1,28 @@
+name: Ruby Gem
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        version: 2.6.x
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}


### PR DESCRIPTION
- We can publish to rubygems when new release is published.  

 RUBYGEMS_AUTH_TOKEN needs to be set for this action to work