### PR TITLE
Ruby 2.4 is eol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7

--- a/spandx.gemspec
+++ b/spandx.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'A ruby interface to the SPDX catalogue. With a CLI that can scan project lockfiles to list out software licenses for each dependency'
   spec.homepage      = 'https://github.com/mokhan/spandx'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/mokhan/spandx'


### PR DESCRIPTION
Shall we not spend computational power for 2.4 ? 

https://endoflife.software/programming-languages/server-side-scripting/ruby