### PR TITLE
Bring back 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,0 @@
-stages:
-  - test
-
-test:
-  stage: test
-  image: ruby:2.6
-  script:
-    - ./bin/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
+  - 2.4
   - 2.5
   - 2.6
   - 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.12.0
+Version 0.12.1
 
 # Changelog
 
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.1] - 2020-04-17
+### Fixed
+- Revert ruby version constraint to support 2.4+
+
 
 ## [0.12.0] - 2020-04-14
 ### Added
@@ -131,7 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Provide ruby API to the latest SPDX catalogue.
 
-[Unreleased]: https://github.com/mokhan/spandx/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/mokhan/spandx/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/mokhan/spandx/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/mokhan/spandx/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mokhan/spandx/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/mokhan/spandx/compare/v0.10.0...v0.10.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spandx (0.12.0)
+    spandx (0.12.1)
       addressable (~> 2.7)
       bundler (>= 1.16, < 3.0.0)
       net-hippie (~> 0.3)

--- a/lib/spandx/version.rb
+++ b/lib/spandx/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spandx
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/spandx.gemspec
+++ b/spandx.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'A ruby interface to the SPDX catalogue. With a CLI that can scan project lockfiles to list out software licenses for each dependency'
   spec.homepage      = 'https://github.com/mokhan/spandx'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/mokhan/spandx'


### PR DESCRIPTION
I'm seeing failures in projects that are still using ruby 2.4. I think I'm going to reschedule the removing of 2.4 in the 1.0.0 release. For now, I'm going to release a patch to return the version constraint back to 2.4.0 in the pre 1.0 version. Then I'll release a new 1.0.0 version that drops support for it.

E.g.

```bash
root@f3c36470c386:/opt/license-management# ./bin/test spec/integration/ruby/bundler_spec.rb:7
Run options: include {:locations=>{"./spec/integration/ruby/bundler_spec.rb"=>[7]}}

Randomized with seed 31209
Installing missing tools…
Downloading ruby-2.4.9.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2
Installing ruby-2.4.9...

WARNING: ruby-2.4.9 is past its end of life and is now unsupported.
It no longer receives bug fixes or critical security updates.

Installed ruby-2.4.9 to /opt/asdf/installs/ruby/2.4.9


Running: gem install bundler --version ~>1.7 ... SUCCESS
Running: gem install bundler --version ~>2.0 ... SUCCESS
Running: gem install license_finder --version ~>6.0.0 ... SUCCESS
Running: gem install spandx --version ~>0.1 ... FAIL: Successfully installed public_suffix-4.0.4
Successfully installed addressable-2.7.0
Successfully installed net-hippie-0.3.2
Successfully installed mini_portile2-2.4.0
Building native extensions.  This could take a while...
ERROR:  Error installing spandx:
        spandx requires Ruby version >= 2.5.0.
Successfully installed nokogiri-1.10.9
Successfully installed zeitwerk-2.3.0
sbt 1.3.8 is already installed
```
/cc @eldemcan 